### PR TITLE
Enable Stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 3
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Enables https://github.com/probot/stale
PRs with no activity for 7 days will be marked as stale and a comment will be posted:

```
This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.
```

After 3 more days with no further activity, the PR will be closed. The branch will not be deleted, and the PR can be reopened any time. To prevent the PR from being closed, a comment can be added to the PR to buy 7 more days of time.